### PR TITLE
Make it work in browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.1",
   "description": "Filesystem methods as promises, with optional fs-extra and fs-graceful dependencies",
   "main": "index.js",
+  "browser": {
+    "fs-extra": false,
+    "graceful-fs": false
+  },
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
At the moment to *browserify* the module, you need both *fs-extra* and *graceful-fs* installed along with a standard [*brfs*](https://github.com/substack/brfs) setup.

Otherwise you get an
```Error: Cannot find module '(fs-extra|graceful-fs)' from '…/node_modules/fs-promise'```

This PR tells *browserify* “Just always use the standard *fs*”.