### PR TITLE
Use fs-extra explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 [![Build Status](https://secure.travis-ci.org/kevinbeaty/fs-promise.svg)](http://travis-ci.org/kevinbeaty/fs-promise)
 
-Proxies all async `fs` methods exposing them as ES 2015 (ES6) compatible promises.
+Proxies all async [`fs`][1] and [`fs-extra`][2] methods exposing them as ES 2015 (ES6) compatible promises.
 
 Passes all sync methods through as values.
-
-Also exposes to [graceful-fs][1] and/or [fs-extra][2] methods if they are installed.
 
 Uses [any-promise][3] to load preferred `Promise` implementation.
 
@@ -22,23 +20,16 @@ fsp.writeFile(file('hello1'), 'hello world')
 
 ## Usage
 
-Attempts to load libraries in the following order. The first successful require will be proxied to a Promise based implementation.
-
-- [`fs-extra`](https://github.com/jprichardson/node-fs-extra)
-- [`graceful-fs`](https://github.com/isaacs/node-graceful-fs)
-- `fs` from standard library
-
 Detects a `Promise` implementation using [`any-promise`][3]. If you have a preferred implementation, or are working in an environment without a global implementation, you must explicitly register a `Promise` implementation and it will be used. See [`any-promise`][3] for details.
 
 Typical installation:
 
 ```bash
-$ npm install --save fs-extra
 $ npm install --save fs-promise
 ```
 
-Note that `fs-extra` depends on `graceful-fs`, so you would get the benefits of both libraries.
+Note that `fs-extra` depends on `graceful-fs`, so you will get the benefits of both libraries.
 
-[1]: https://github.com/isaacs/node-graceful-fs
+[1]: https://nodejs.org/api/fs.html
 [2]: https://www.npmjs.org/package/fs-extra
 [3]: https://github.com/kevinbeaty/any-promise

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-promise",
   "version": "0.4.1",
-  "description": "Filesystem methods as promises, with optional fs-extra and fs-graceful dependencies",
+  "description": "Filesystem methods as promises with fs-extra",
   "main": "index.js",
   "scripts": {
     "test": "mocha"
@@ -19,7 +19,8 @@
   "author": "Kevin Beaty",
   "license": "MIT",
   "dependencies": {
-    "any-promise": "^1.0.0"
+    "any-promise": "^1.0.0",
+    "fs-extra": "^0.26.5"
   },
   "devDependencies": {
     "mocha": "~2.4.2",


### PR DESCRIPTION
This would evolve `fs-promise` into an alternative to `fs-extra-promise` backed by any-promise. This would change `fs-promise` to use `fs-extra` explicitly. I have tried to keep the changes very minimal and to the point.