### PR TITLE
add readable stream support (handle walk method properly)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var Promise = require('any-promise');
 var slice = Array.prototype.slice;
 
 var keys = Object.keys(fs);
-var promiseKeys = ['access', 'readFile', 'close', 'open', 'read', 'write', 'rename', 'truncate', 'ftruncate', 'rmdir', 'fdatasync', 'fsync', 'mkdir', 'readdir', 'fstat', 'lstat', 'stat', 'readlink', 'symlink', 'link', 'unlink', 'fchmod', 'lchmod', 'chmod', 'lchown', 'fchown', 'chown', '_toUnixTimestamp', 'utimes', 'futimes', 'writeFile', 'appendFile', 'realpath', 'lutimes', 'gracefulify', 'copy', 'mkdirs', 'mkdirp', 'ensureDir', 'remove', 'readJson', 'readJSON', 'writeJson', 'writeJSON', 'outputJson', 'outputJSON', 'move', 'createOutputStream', 'emptyDir', 'emptydir', 'createFile', 'ensureFile', 'createLink', 'ensureLink', 'createSymlink', 'ensureSymlink', 'outputFile', 'walk'];
+var promiseKeys = ['access', 'readFile', 'close', 'open', 'read', 'write', 'rename', 'truncate', 'ftruncate', 'rmdir', 'fdatasync', 'fsync', 'mkdir', 'readdir', 'fstat', 'lstat', 'stat', 'readlink', 'symlink', 'link', 'unlink', 'fchmod', 'lchmod', 'chmod', 'lchown', 'fchown', 'chown', '_toUnixTimestamp', 'utimes', 'futimes', 'writeFile', 'appendFile', 'realpath', 'lutimes', 'gracefulify', 'copy', 'mkdirs', 'mkdirp', 'ensureDir', 'remove', 'readJson', 'readJSON', 'writeJson', 'writeJSON', 'outputJson', 'outputJSON', 'move', 'createOutputStream', 'emptyDir', 'emptydir', 'createFile', 'ensureFile', 'createLink', 'ensureLink', 'createSymlink', 'ensureSymlink', 'outputFile'];
+var streamKeys = ['walk'];
 var noErrorKeys = ['exists'];
 
 keys.forEach(function (key) {
@@ -35,6 +36,26 @@ keys.forEach(function (key) {
         args.push(resolve);
 
         func.apply(fs, args);
+      });
+    };
+  } else if (streamKeys.indexOf(key) !== -1) {
+    exports[key] = function () {
+      var args = slice.call(arguments);
+
+      return new Promise(function (resolve, reject) {
+        var stream = func.apply(fs, args);
+        var items = [];
+
+        stream
+          .on('data', function (item) {
+            items.push(item);
+          })
+          .on('end', function () {
+            resolve(items);
+          })
+          .on('error', function (error) {
+            reject(error);
+          });
       });
     };
   } else {


### PR DESCRIPTION
This pull request adds support for the [fs-extra's walk method](https://github.com/jprichardson/node-fs-extra#walk).

Currently the _fs-promise_ will use `walk()` method as any other and creates a _Promise_ if it's called.
Unfortunately this is a special method of _fs-extra_ and returns a _Readable stream_. The resolver will never call either the `resolve()` or the `reject()` method and the promise will hang forever because the nature of the stream demands to register listeners to events like `'data'` or `'error'`.

See example:
```javascript
var fse = require('fs-extra');
var fsp = require('fs-promise');
const DIR = '/tmp';

var fseItems = [];
var fseWalking = fse.walk(DIR);
// copied from fs-extra documentation
fseWalking
    .on('data', function (item) {
        fseItems.push(item.path);
    })
    .on('end', function () {
        // will print all items in the directory
        console.dir(fseItems);
    })
    .on('error', function (error) {
        // will print the error
        console.log(error);
    });

var fspWalking = fsp.walk(DIR);
fspWalking
    .then(function () {
        // never called
        console.log('.then');
        console.log(arguments.length);
        console.log(arguments);
    })
    .catch(function () {
        // never called
        console.log('.catch');
        console.log(arguments.length);
        console.log(arguments);
    });

console.log(fspWalking); // pending
```

With this commit the `fs-promise` will have a basic support for it and the example will execute as expected.

Because `walk()` returns the files one-by-one the wrapper method creates an array and will return the collection after the _end_ event is dispatched. This needs to be supervised if the _fs-extra_ package introduces a new method with stream support but right now I think this will do the trick.