### PR TITLE
Move Types dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   "author": "Kevin Beaty",
   "license": "MIT",
   "dependencies": {
-    "@types/fs-extra": "0.0.37",
-    "@types/mz": "0.0.30",
     "any-promise": "^1.3.0",
     "fs-extra": "^2.0.0",
     "mz": "^2.6.0",
     "thenify-all": "^1.6.0"
   },
   "devDependencies": {
+    "@types/fs-extra": "0.0.37",
+    "@types/mz": "0.0.30",
     "mocha": "^3.0.0",
     "es6-promise": "^4.0.0",
     "rsvp": "^3.0.0",


### PR DESCRIPTION
This is causing Types conflicts as @types/fs-extra is including @types/node as well (see https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/332 for example)